### PR TITLE
Simplify new chat creation and add reset/clear button

### DIFF
--- a/Ollamac/ViewModels/MessageViewModel.swift
+++ b/Ollamac/ViewModels/MessageViewModel.swift
@@ -98,6 +98,10 @@ final class MessageViewModel {
         try? self.modelContext.saveChanges()
     }
     
+    func resetHistory() {
+        self.messages = []
+    }
+    
     private func handleReceive(_ response: OKGenerateResponse) {
         if self.messages.isEmpty { return }
         

--- a/Ollamac/Views/ChatViews/AddChatView.swift
+++ b/Ollamac/Views/ChatViews/AddChatView.swift
@@ -20,7 +20,6 @@ struct AddChatView: View {
     
     @State private var viewState: ViewState? = .loading
     
-    @State private var name: String = "New Chat"
     @State private var selectedModel: OllamaModel?
     
     init(onCreated: @escaping (_ chat: Chat) -> Void) {
@@ -28,7 +27,6 @@ struct AddChatView: View {
     }
     
     private var createButtonDisabled: Bool {
-        if name.isEmpty { return true }
         if selectedModel.isNil { return true }
         if let selectedModel, selectedModel.isNotAvailable { return true }
         
@@ -47,9 +45,6 @@ struct AddChatView: View {
         NavigationStack {
             Form {
                 Section {
-                    TextField("Name", text: $name)
-                        .disabled(isLoading)
-                    
                     Picker("Model", selection: $selectedModel) {
                         Text("Select a model")
                             .tag(nil as OllamaModel?)
@@ -134,7 +129,8 @@ struct AddChatView: View {
     }
     
     private func createAction() {
-        let chat = Chat(name: name)
+        let modelName = selectedModel?.name ?? "untitled"
+        let chat = Chat(name: modelName)
         chat.model = selectedModel
         
         Task {

--- a/Ollamac/Views/MessageViews/MessageView.swift
+++ b/Ollamac/Views/MessageViews/MessageView.swift
@@ -90,6 +90,14 @@ struct MessageView: View {
                     .buttonStyle(.borderedProminent)
                     .visible(if: isGenerating, removeCompletely: true)
                     
+                    Button(action: messageViewModel.resetHistory) {
+                        Image(systemName: "trash.circle.fill")
+                            .padding(8)
+                            .help("Reset History")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .visible(if: messageViewModel.messages.count > 1, removeCompletely: true)
+                    
                     Button(action: sendAction) {
                         Image(systemName: "paperplane.fill")
                             .padding(8)


### PR DESCRIPTION
# Why?

1. By default all new chats end up looking like "New chat" in the sidebar, adding the name is not really a use case as such - ideally people would try out the model, hence we can just use the name of the model as the name.
2. There is currently no way to clear the context history and reset the chat - this adds a button for it.

Sidebar | New Chat
--- | ---
![Screenshot 2023-11-21 at 11 29 59 PM](https://github.com/kevinhermawan/Ollamac/assets/543981/385e5e29-4545-44db-9989-efc9b9397280) | ![Screenshot 2023-11-21 at 11 30 07 PM](https://github.com/kevinhermawan/Ollamac/assets/543981/98f38262-31a5-44a9-903d-3c0cead135ef)
