### PR TITLE
docs: Add homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ Before using Ollamac, ensure the following requirements are met:
 - **Operating System**: macOS 14 or later.
 - **Ollama Setup**: The Ollama system should be installed on your Mac. Ensure you have at least one Ollama model downloaded for interaction.
 
-## Download
+## Install
+
+### Homebrew
+
+```
+brew install --cask ollamac
+```
+
+### Download Directly
 
 You can download the latest version of Ollamac from the [releases page](https://github.com/kevinhermawan/Ollamac/releases).
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before using Ollamac, ensure the following requirements are met:
 brew install --cask ollamac
 ```
 
-### Download Directly
+### Download from GitHub
 
 You can download the latest version of Ollamac from the [releases page](https://github.com/kevinhermawan/Ollamac/releases).
 


### PR DESCRIPTION
I recently added a Homebrew cask for Ollamac: Homebrew/homebrew-cask#166353

This updates the README to include instructions on how to install Ollamac via Homebrew.

Resolves #36.