### PR TITLE
feat: adds custom host

### DIFF
--- a/CoreExtensions/Package.swift
+++ b/CoreExtensions/Package.swift
@@ -11,9 +11,13 @@ let package = Package(
             name: "CoreExtensions",
             targets: ["CoreExtensions"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/sindresorhus/Defaults.git", .upToNextMajor(from: "8.2.0"))
+    ],
     targets: [
         .target(
-            name: "CoreExtensions"),
-        
+            name: "CoreExtensions",
+            dependencies: ["Defaults"]
+        ),
     ]
 )

--- a/CoreExtensions/Sources/CoreExtensions/Defaults+Keys.swift
+++ b/CoreExtensions/Sources/CoreExtensions/Defaults+Keys.swift
@@ -1,0 +1,13 @@
+//
+//  Defaults+Keys.swift
+//
+//
+//  Created by Kevin Hermawan on 13/07/24.
+//
+
+import Defaults
+import Foundation
+
+public extension Defaults.Keys {
+    static let defaultHost = Key<String>("defaultHost", default: "http://localhost:11434")
+}

--- a/CoreExtensions/Sources/CoreExtensions/String+IsValidURL.swift
+++ b/CoreExtensions/Sources/CoreExtensions/String+IsValidURL.swift
@@ -1,0 +1,17 @@
+//
+//  String+IsValidURL.swift
+//
+//
+//  Created by Kevin Hermawan on 13/07/24.
+//
+
+import Foundation
+
+public extension String {
+    func isValidURL() -> Bool {
+        let urlRegEx = #"^(http|https):\/\/((([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})|(localhost))(:[0-9]{1,5})?(\/[^\s]*)?$"#
+        let urlTest = NSPredicate(format:"SELF MATCHES %@", urlRegEx)
+        
+        return urlTest.evaluate(with: self)
+    }
+}

--- a/CoreExtensions/Sources/CoreExtensions/String+RemoveTrailingSlash.swift
+++ b/CoreExtensions/Sources/CoreExtensions/String+RemoveTrailingSlash.swift
@@ -1,0 +1,14 @@
+//
+//  String+RemoveTrailingSlash.swift
+//
+//
+//  Created by Kevin Hermawan on 13/07/24.
+//
+
+import Foundation
+
+public extension String {
+    func removeTrailingSlash() -> String {
+        return self.hasSuffix("/") ? String(self.dropLast()) : self
+    }
+}

--- a/Ollamac.xcodeproj/project.pbxproj
+++ b/Ollamac.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0A2C4E342C426974007794CC /* CoreExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 0A2C4E332C426974007794CC /* CoreExtensions */; };
 		0A2C4E392C426D05007794CC /* CoreModels in Frameworks */ = {isa = PBXBuildFile; productRef = 0A2C4E382C426D05007794CC /* CoreModels */; };
 		0A2C4E3C2C427094007794CC /* CoreViewModels in Frameworks */ = {isa = PBXBuildFile; productRef = 0A2C4E3B2C427094007794CC /* CoreViewModels */; };
+		0A2C4E3F2C427713007794CC /* SettingsModule in Frameworks */ = {isa = PBXBuildFile; productRef = 0A2C4E3E2C427713007794CC /* SettingsModule */; };
+		0A2C4E422C428F5E007794CC /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 0A2C4E412C428F5E007794CC /* Defaults */; };
 		0A4D35852AF541D900846890 /* OllamacApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4D35842AF541D900846890 /* OllamacApp.swift */; };
 		0A4D358B2AF541DA00846890 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A4D358A2AF541DA00846890 /* Assets.xcassets */; };
 		0A4D358E2AF541DA00846890 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A4D358D2AF541DA00846890 /* Preview Assets.xcassets */; };
@@ -40,6 +42,7 @@
 /* Begin PBXFileReference section */
 		0A2C4E372C426C06007794CC /* CoreModels */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = CoreModels; sourceTree = "<group>"; };
 		0A2C4E3A2C427059007794CC /* CoreViewModels */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = CoreViewModels; sourceTree = "<group>"; };
+		0A2C4E3D2C427601007794CC /* SettingsModule */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SettingsModule; sourceTree = "<group>"; };
 		0A4D35812AF541D900846890 /* Ollamac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ollamac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A4D35842AF541D900846890 /* OllamacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamacApp.swift; sourceTree = "<group>"; };
 		0A4D358A2AF541DA00846890 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -69,6 +72,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0AE024832AFB898300347C18 /* Sparkle in Frameworks */,
+				0A2C4E3F2C427713007794CC /* SettingsModule in Frameworks */,
 				0AA41A172AF635AD0053B8DB /* ViewState in Frameworks */,
 				0A2C4E3C2C427094007794CC /* CoreViewModels in Frameworks */,
 				0ACA4D762AF89C27000DA76F /* MarkdownUI in Frameworks */,
@@ -78,6 +82,7 @@
 				0AB30EB22B272A67009C038A /* ChatField in Frameworks */,
 				0A2C4E342C426974007794CC /* CoreExtensions in Frameworks */,
 				0ACA4D5E2AF7AC43000DA76F /* SwiftUIIntrospect in Frameworks */,
+				0A2C4E422C428F5E007794CC /* Defaults in Frameworks */,
 				0AE0248B2AFEA24600347C18 /* OllamaKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -96,9 +101,10 @@
 		0A4D35782AF541D900846890 = {
 			isa = PBXGroup;
 			children = (
-				0A2C4E3A2C427059007794CC /* CoreViewModels */,
 				0A7F58F92C42606000091E44 /* CoreExtensions */,
 				0A2C4E372C426C06007794CC /* CoreModels */,
+				0A2C4E3A2C427059007794CC /* CoreViewModels */,
+				0A2C4E3D2C427601007794CC /* SettingsModule */,
 				0A7F58FA2C42657E00091E44 /* Frameworks */,
 				0A4D35832AF541D900846890 /* Ollamac */,
 				0A4D35822AF541D900846890 /* Products */,
@@ -145,12 +151,12 @@
 		0A4D35962AF5422A00846890 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				0A7F58F72C425CA500091E44 /* ChatPreferences */,
-				0AB362A32C398F4000DE3F31 /* Subviews */,
 				0A4D35982AF5425900846890 /* AppView.swift */,
+				0A7F58F72C425CA500091E44 /* ChatPreferences */,
 				0ACA4D4F2AF799A5000DA76F /* ChatViews */,
 				0A20FFA12B21463F00112783 /* Commons */,
 				0ACA4D522AF7A788000DA76F /* MessageViews */,
+				0AB362A32C398F4000DE3F31 /* Subviews */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -246,6 +252,8 @@
 				0A2C4E332C426974007794CC /* CoreExtensions */,
 				0A2C4E382C426D05007794CC /* CoreModels */,
 				0A2C4E3B2C427094007794CC /* CoreViewModels */,
+				0A2C4E3E2C427713007794CC /* SettingsModule */,
+				0A2C4E412C428F5E007794CC /* Defaults */,
 			);
 			productName = Ollamac;
 			productReference = 0A4D35812AF541D900846890 /* Ollamac.app */;
@@ -284,6 +292,7 @@
 				0AE024892AFEA24600347C18 /* XCRemoteSwiftPackageReference "OllamaKit" */,
 				0AB30EB02B272A67009C038A /* XCRemoteSwiftPackageReference "ChatField" */,
 				0AB362A02C398ED700DE3F31 /* XCRemoteSwiftPackageReference "Highlightr" */,
+				0A2C4E402C428F5E007794CC /* XCRemoteSwiftPackageReference "Defaults" */,
 			);
 			productRefGroup = 0A4D35822AF541D900846890 /* Products */;
 			projectDirPath = "";
@@ -542,6 +551,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0A2C4E402C428F5E007794CC /* XCRemoteSwiftPackageReference "Defaults" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/Defaults.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.2.0;
+			};
+		};
 		0AA41A152AF635AD0053B8DB /* XCRemoteSwiftPackageReference "ViewState" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kevinhermawan/ViewState.git";
@@ -620,6 +637,15 @@
 		0A2C4E3B2C427094007794CC /* CoreViewModels */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CoreViewModels;
+		};
+		0A2C4E3E2C427713007794CC /* SettingsModule */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SettingsModule;
+		};
+		0A2C4E412C428F5E007794CC /* Defaults */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0A2C4E402C428F5E007794CC /* XCRemoteSwiftPackageReference "Defaults" */;
+			productName = Defaults;
 		};
 		0AA41A162AF635AD0053B8DB /* ViewState */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Ollamac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ollamac.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "defaults",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/Defaults.git",
+      "state" : {
+        "revision" : "38925e3cfacf3fb89a81a35b1cd44fd5a5b7e0fa",
+        "version" : "8.2.0"
+      }
+    },
+    {
       "identity" : "highlightr",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/raspu/Highlightr.git",
@@ -77,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kevinhermawan/ViewState.git",
       "state" : {
-        "revision" : "8e5a5efbbf3fb5a2d2621533a115a9da031214cb",
-        "version" : "1.2.1"
+        "revision" : "6c85c207c23edf487007542651e3533a80dfa0bc",
+        "version" : "1.2.2"
       }
     }
   ],

--- a/Ollamac/App/OllamacApp.swift
+++ b/Ollamac/App/OllamacApp.swift
@@ -7,7 +7,9 @@
 
 import CoreModels
 import CoreViewModels
+import Defaults
 import OllamaKit
+import SettingsModule
 import Sparkle
 import SwiftUI
 import SwiftData
@@ -35,11 +37,11 @@ struct OllamacApp: App {
     
     init() {
         let modelContext = sharedModelContainer.mainContext
-                
+        
         let commandViewModel = CommandViewModel()
         _commandViewModel = State(initialValue: commandViewModel)
         
-        let ollamaURL = URL(string: "http://localhost:11434")!
+        let ollamaURL = URL(string: Defaults[.defaultHost])!
         let ollamaKit = OllamaKit(baseURL: ollamaURL)
         
         let ollamaViewModel = OllamaViewModel(ollamaKit: ollamaKit)
@@ -87,6 +89,10 @@ struct OllamacApp: App {
                     ChatContextMenu(commandViewModel, for: selectedChat)
                 }
             }
+        }
+        
+        Settings {
+            SettingsView()
         }
     }
 }

--- a/SettingsModule/.gitignore
+++ b/SettingsModule/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/SettingsModule/Package.swift
+++ b/SettingsModule/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SettingsModule",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(
+            name: "SettingsModule",
+            targets: ["SettingsModule"]),
+    ],
+    dependencies: [
+        .package(name: "CoreExtensions", path: "../CoreExtensions"),
+        .package(url: "https://github.com/kevinhermawan/OllamaKit.git", .upToNextMajor(from: "5.0.0")),
+        .package(url: "https://github.com/kevinhermawan/ViewState.git", .upToNextMajor(from: "1.2.2")),
+        .package(url: "https://github.com/sindresorhus/Defaults.git", .upToNextMajor(from: "8.2.0"))
+    ],
+    targets: [
+        .target(
+            name: "SettingsModule",
+            dependencies: ["CoreExtensions", "OllamaKit", "ViewState", "Defaults"]
+        ),
+    ]
+)

--- a/SettingsModule/Sources/SettingsModule/GeneralView.swift
+++ b/SettingsModule/Sources/SettingsModule/GeneralView.swift
@@ -1,0 +1,60 @@
+//
+//  GeneralView.swift
+//
+//
+//  Created by Kevin Hermawan on 13/07/24.
+//
+
+import CoreExtensions
+import Defaults
+import OllamaKit
+import SwiftUI
+import ViewState
+
+struct GeneralView: View {
+    @State private var defaultHost: String = ""
+    @Default(.defaultHost) private var defaultHostDefault
+    
+    @State private var defaultHostViewState: ViewState? = nil
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GroupBox {
+                DefaultHostTextField(defaultHost: $defaultHost, viewState: $defaultHostViewState, saveAction: saveDefaultHostAction)
+            }
+        }
+        .onAppear {
+            defaultHost = defaultHostDefault
+        }
+        .onDisappear {
+            defaultHostViewState = nil
+        }
+    }
+    
+    func saveDefaultHostAction() {
+        defaultHostViewState = .loading
+        
+        Task {
+            let sanitizedHost = defaultHost.removeTrailingSlash()
+            
+            guard sanitizedHost.isValidURL(), let baseURL = URL(string: sanitizedHost) else {
+                defaultHostViewState = .error(message: "The URL is invalid")
+                return
+            }
+            
+            let ollamaKit = OllamaKit(baseURL: baseURL)
+            
+            guard await ollamaKit.reachable() else {
+                defaultHostViewState = .error(message: "The host is not reachable")
+                return
+            }
+            
+            defaultHostDefault = sanitizedHost
+            defaultHostViewState = .success(message: "The default host is updated")
+        }
+    }
+}
+
+#Preview {
+    GeneralView()
+}

--- a/SettingsModule/Sources/SettingsModule/SettingsView.swift
+++ b/SettingsModule/Sources/SettingsModule/SettingsView.swift
@@ -1,0 +1,29 @@
+//
+//  SettingsView.swift
+//
+//
+//  Created by Kevin Hermawan on 13/07/24.
+//
+
+import SwiftUI
+
+public struct SettingsView: View {
+    public init() {}
+    
+    public var body: some View {
+        VStack {
+            TabView {
+                GeneralView()
+                    .tabItem {
+                        Label("General", systemImage: "gearshape")
+                    }
+            }
+        }
+        .padding()
+        .frame(width: 450)
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/SettingsModule/Sources/SettingsModule/Subviews/DefaultHostTextField.swift
+++ b/SettingsModule/Sources/SettingsModule/Subviews/DefaultHostTextField.swift
@@ -1,0 +1,109 @@
+//
+//  DefaultHostTextField.swift
+//
+//
+//  Created by Kevin Hermawan on 13/07/24.
+//
+
+import SwiftUI
+import ViewState
+
+struct DefaultHostTextField: View {
+    @Binding private var defaultHost: String
+    @Binding private var viewState: ViewState?
+    private var saveAction: () -> Void
+    
+    public init(defaultHost: Binding<String>, viewState: Binding<ViewState?>, saveAction: @escaping () -> Void) {
+        self._defaultHost = defaultHost
+        self._viewState = viewState
+        self.saveAction = saveAction
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Default Host")
+                .font(.headline.weight(.semibold))
+            
+            TextField("http://localhost:11434", text: $defaultHost)
+                .textFieldStyle(.roundedBorder)
+            
+            HStack {
+                EmptyView()
+                    .when(viewState, is: .loading) {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    .whenSuccess(viewState) { message in
+                        Text(message)
+                            .foregroundStyle(.green)
+                    }
+                    .whenError(viewState) { message in
+                        Text(message)
+                            .foregroundStyle(.red)
+                    }
+                
+                Spacer()
+                
+                Button("Save", action: saveAction)
+                    .disabled(viewState == .loading)
+                    .disabled(defaultHost.isEmpty)
+            }
+        }
+        .padding(4)
+    }
+}
+
+#Preview("Default") {
+    VStack {
+        GroupBox {
+            DefaultHostTextField(defaultHost: .constant("http://localhost:11434"), viewState: .constant(.none)) {
+                
+            }
+        }
+    }
+    .padding(16)
+}
+
+#Preview("Empty") {
+    VStack {
+        GroupBox {
+            DefaultHostTextField(defaultHost: .constant(""), viewState: .constant(.none)) {
+                
+            }
+        }
+    }
+    .padding(16)
+}
+
+#Preview("Loading") {
+    VStack {
+        GroupBox {
+            DefaultHostTextField(defaultHost: .constant("http://localhost:11434"), viewState: .constant(.loading)) {
+                
+            }
+        }
+    }
+    .padding(16)
+}
+
+#Preview("Success") {
+    VStack {
+        GroupBox {
+            DefaultHostTextField(defaultHost: .constant("http://localhost:11434"), viewState: .constant(.success(message: "Operation successful"))) {
+                
+            }
+        }
+    }
+    .padding(16)
+}
+
+#Preview("Error") {
+    VStack {
+        GroupBox {
+            DefaultHostTextField(defaultHost: .constant("http://localhost:11434"), viewState: .constant(.error(message: "An error occurred"))) {
+                
+            }
+        }
+    }
+    .padding(16)
+}


### PR DESCRIPTION
This pull request involves adding the default host. You might wonder why it's named "default host" instead of "host". The reason is that I intend to add a custom host for each chat in the future. But for now, when you change the default host, all conversations (including the previous chats) will use that host.

This PR solves #2 & #60