### PR TITLE
Increase margin and enable wrapping of bullet point items

### DIFF
--- a/Ollamac/Extensions/Theme+Ollamac.swift
+++ b/Ollamac/Extensions/Theme+Ollamac.swift
@@ -33,6 +33,11 @@ class ThemeCache {
                 .codeBlock { [weak self] configuration in
                     self?.getCodeBlockView(for: configuration) ?? CodeBlockView(configuration: configuration)
                 }
+                .listItem { configuration in
+                    configuration.label
+                        .markdownMargin(top: .em(0.5))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             
             cachedTheme = newTheme
             


### PR DESCRIPTION
Currently the bullet points that do not fit in the width of the screen are truncated with a '...' at the end instead of being wrapped. Additionally (and this depends on individual taste) the list items are rendered in a way that's a little too crowded.

This PR fixes the first issue, and increases the margin between bullet point items.