### PR TITLE
Fix syntax highlighting issues

### DIFF
--- a/Ollamac/App/OllamacApp.swift
+++ b/Ollamac/App/OllamacApp.swift
@@ -18,7 +18,8 @@ struct OllamacApp: App {
     
     @State private var chatViewModel: ChatViewModel
     @State private var messageViewModel: MessageViewModel
-    
+    @State private var codeHighlighter: CodeHighlighter
+
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([Chat.self, Message.self])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
@@ -44,7 +45,10 @@ struct OllamacApp: App {
         
         let messageViewModel = MessageViewModel(modelContext: modelContext)
         self._messageViewModel = State(initialValue: messageViewModel)
-        
+
+        let codeHighlighter =  CodeHighlighter()
+        _codeHighlighter = State(initialValue: codeHighlighter)
+
         chatViewModel.create(model: Defaults[.defaultModel])
         guard let activeChat = chatViewModel.selectedChats
             .first else { return }
@@ -58,6 +62,7 @@ struct OllamacApp: App {
             AppView()
                 .environment(chatViewModel)
                 .environment(messageViewModel)
+                .environment(codeHighlighter)
         }
         .modelContainer(sharedModelContainer)
         .commands {

--- a/Ollamac/Extensions/Theme+Ollamac.swift
+++ b/Ollamac/Extensions/Theme+Ollamac.swift
@@ -30,8 +30,8 @@ class ThemeCache {
                     FontSize(15.0)
                     FontFamilyVariant(.monospaced)
                 }
-                .codeBlock { [weak self] configuration in
-                    self?.getCodeBlockView(for: configuration) ?? CodeBlockView(configuration: configuration)
+                .codeBlock { configuration in
+                    CodeBlockView(configuration: configuration)
                 }
             
             cachedTheme = newTheme
@@ -40,16 +40,16 @@ class ThemeCache {
         }
     }
     
-    private func getCodeBlockView(for configuration: CodeBlockConfiguration) -> CodeBlockView {
-        if let cachedView = cachedCodeBlocks[configuration] {
-            return cachedView
-        } else {
-            let newView = CodeBlockView(configuration: configuration)
-            cachedCodeBlocks[configuration] = newView
-            
-            return newView
-        }
-    }
+//    private func getCodeBlockView(for configuration: CodeBlockConfiguration) -> CodeBlockView {
+//        if let cachedView = cachedCodeBlocks[configuration] {
+//            return cachedView
+//        } else {
+//            let newView = CodeBlockView(configuration: configuration)
+//            cachedCodeBlocks[configuration] = newView
+//            
+//            return newView
+//        }
+//    }
 }
 
 extension Theme {

--- a/Ollamac/Utils/CodeBlockView.swift
+++ b/Ollamac/Utils/CodeBlockView.swift
@@ -9,6 +9,8 @@ import MarkdownUI
 import SwiftUI
 
 struct CodeBlockView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let configuration: CodeBlockConfiguration
     @State private var isCopied = false
     
@@ -35,20 +37,28 @@ struct CodeBlockView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
-            .background(Color(hex: "#373941"))
-            
+            .background(headerBackground)
+
             configuration.label
                 .padding(.top, 8)
                 .padding(.bottom)
                 .padding(.horizontal)
                 .monospaced()
         }
-        .background(Color(hex: "#20242b"))
+        .background(codeBackground)
         .cornerRadius(8)
         .overlay(
             RoundedRectangle(cornerRadius: 8)
                 .stroke(.secondary, lineWidth: 0.2)
         )
+    }
+
+    var headerBackground: some View {
+        Color.primary.brightness(colorScheme == .dark ? -0.8 : 0.2)
+    }
+
+    var codeBackground: some View {
+        Color.primary.brightness(colorScheme == .dark ? -0.85 : 0.95)
     }
     
     private func copyCodeAction() {

--- a/Ollamac/Utils/CodeBlockView.swift
+++ b/Ollamac/Utils/CodeBlockView.swift
@@ -9,7 +9,7 @@ import MarkdownUI
 import SwiftUI
 
 struct CodeBlockView: View {
-    @Environment(\.colorScheme) private var colorScheme
+    @Environment(CodeHighlighter.self) private var codeHighlighter
 
     let configuration: CodeBlockConfiguration
     @State private var isCopied = false
@@ -32,7 +32,7 @@ struct CodeBlockView: View {
                 .cornerRadius(4)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
-                        .stroke(Color(hex: "#a5a5a9"), lineWidth: 1)
+                        .stroke(borderColor, lineWidth: 1)
                 )
             }
             .padding(.horizontal)
@@ -54,11 +54,15 @@ struct CodeBlockView: View {
     }
 
     var headerBackground: some View {
-        Color.primary.brightness(colorScheme == .dark ? -0.8 : 0.2)
+        Color.primary.brightness(codeHighlighter.scheme == .dark ? -0.8 : 0.2)
+    }
+
+    var borderColor: Color {
+        codeHighlighter.scheme == .dark ? Color(hex: "#a5a5a9") : Color.gray
     }
 
     var codeBackground: some View {
-        Color.primary.brightness(colorScheme == .dark ? -0.85 : 0.95)
+        Color.primary.brightness(codeHighlighter.scheme == .dark ? -0.85 : 0.95)
     }
     
     private func copyCodeAction() {

--- a/Ollamac/Utils/CodeHighlighter.swift
+++ b/Ollamac/Utils/CodeHighlighter.swift
@@ -9,56 +9,41 @@ import Highlightr
 import MarkdownUI
 import SwiftUI
 
-struct CodeHighlighter: CodeSyntaxHighlighter {
+@Observable
+class CodeHighlighter: CodeSyntaxHighlighter {
     private let highlightr: Highlightr
-    
+    private(set) var scheme: ColorScheme = .dark
+
     init() {
+        print(Self.self, #function)
         guard let highlightrInstance = Highlightr() else {
             fatalError("Failed to initialize Highlightr")
         }
-        
+
         self.highlightr = highlightrInstance
         self.highlightr.setTheme(to: "atom-one-dark")
     }
-    
+
     func highlightCode(_ code: String, language: String?) -> Text {
         let highlightedCode: NSAttributedString?
-        
+
         if let language, !language.isEmpty {
             highlightedCode = highlightr.highlight(code, as: language)
         } else {
             highlightedCode = highlightr.highlight(code)
         }
-        
+
         guard let highlightedCode else { return Text(code) }
-        
+
         var attributedCode = AttributedString(highlightedCode)
         attributedCode.font = .system(size: 15, design: .monospaced)
-        
+
         return Text(attributedCode)
     }
-}
 
-class CodeHighlighterCache {
-    static let shared = CodeHighlighterCache()
-    private var highlighter: CodeHighlighter?
-    
-    private init() {}
-    
-    func getHighlighter() -> CodeHighlighter {
-        if let existingHighlighter = highlighter {
-            return existingHighlighter
-        } else {
-            let newHighlighter = CodeHighlighter()
-            highlighter = newHighlighter
-            
-            return newHighlighter
-        }
-    }
-}
-
-extension CodeSyntaxHighlighter where Self == CodeHighlighter {
-    static var ollamac: Self {
-        CodeHighlighterCache.shared.getHighlighter()
+    func setColorScheme(to scheme: ColorScheme) {
+        let newTheme = scheme == .dark ? "atom-one-dark" : "atom-one-light"
+        self.highlightr.setTheme(to: newTheme)
+        self.scheme = scheme
     }
 }

--- a/Ollamac/Utils/CodeHighlighter.swift
+++ b/Ollamac/Utils/CodeHighlighter.swift
@@ -15,7 +15,6 @@ class CodeHighlighter: CodeSyntaxHighlighter {
     private(set) var scheme: ColorScheme = .dark
 
     init() {
-        print(Self.self, #function)
         guard let highlightrInstance = Highlightr() else {
             fatalError("Failed to initialize Highlightr")
         }

--- a/Ollamac/Views/Chats/ChatView.swift
+++ b/Ollamac/Views/Chats/ChatView.swift
@@ -14,7 +14,9 @@ import ViewCondition
 struct ChatView: View {
     @Environment(ChatViewModel.self) private var chatViewModel
     @Environment(MessageViewModel.self) private var messageViewModel
-    
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(CodeHighlighter.self) private var codeHighlighter
+
     @State private var ollamaKit: OllamaKit
     @State private var prompt: String = ""
     @State private var scrollProxy: ScrollViewProxy? = nil
@@ -102,6 +104,9 @@ struct ChatView: View {
                 if let proxy = scrollProxy {
                     scrollToBottom(proxy: proxy)
                 }
+            }
+            .onChange(of: colorScheme, initial: true) {
+                codeHighlighter.setColorScheme(to: colorScheme)
             }
         }
         .navigationTitle(chatViewModel.activeChat?.name ?? "Ollamac")

--- a/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
+++ b/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
@@ -16,7 +16,10 @@ struct AssistantMessageView: View {
     private let isLastMessage: Bool
     private let copyAction: (_ content: String) -> Void
     private let regenerateAction: () -> Void
-    
+
+    @Environment(CodeHighlighter.self) private var codeHighlighter
+    @AppStorage("experimentalCodeHighlighting") private var experimentalCodeHighlighting = false
+
     init(content: String, isGenerating: Bool, isLastMessage: Bool, copyAction: @escaping (_ content: String) -> Void, regenerateAction: @escaping () -> Void) {
         self.content = content
         self.isGenerating = isGenerating
@@ -38,10 +41,9 @@ struct AssistantMessageView: View {
                 Markdown(content)
                     .textSelection(.enabled)
                     .markdownTheme(.ollamac)
-                    .if(Defaults[.experimentalCodeHighlighting]) { view in
-                        view.markdownCodeSyntaxHighlighter(.ollamac)
-                    }
-                
+                    .markdownCodeSyntaxHighlighter(experimentalCodeHighlighting ? codeHighlighter : .plainText)
+                    .id(experimentalCodeHighlighting.hashValue &+ codeHighlighter.scheme.hashValue)
+
                 HStack(spacing: 16) {
                     MessageButton("Copy", systemImage: "doc.on.doc", action: { copyAction(content) })
                     


### PR DESCRIPTION
This PR reimplements the "features" of PR #84 which is outdated.

This fixes "unreadable code" problem (as in #113) when no code highlighting is enabled.
It also enables dynamic switching of dark/light mode and enabling/disabling syntax highlighting "on the fly".

- `CodeBlocks` derive background colors from color scheme (instead of hardcoded colors)
- `CodeBlocks` should depend on unique `CodeHighlighter` instance
- `CodeHighlighter` handles color scheme and applies it to highlightr theme ("atom-one-dark" or "atom-one-light").
- `ChatView` monitors current color scheme and calls-back `CodeHighlighter`
