### PR TITLE
Avoid empty prompts

### DIFF
--- a/Ollamac/Views/Chats/ChatView.swift
+++ b/Ollamac/Views/Chats/ChatView.swift
@@ -141,7 +141,12 @@ struct ChatView: View {
     
     private func generateAction() {
         guard let activeChat = chatViewModel.activeChat, !activeChat.model.isEmpty, chatViewModel.isHostReachable else { return }
-        guard !prompt.isEmpty else { return }
+
+        let prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            self.prompt = ""
+            return
+        }
 
         if messageViewModel.loading == .generate {
             messageViewModel.cancelGeneration()
@@ -151,7 +156,7 @@ struct ChatView: View {
             messageViewModel.generate(ollamaKit, activeChat: activeChat, prompt: prompt)
         }
         
-        prompt = ""
+        self.prompt = ""
     }
     
     private func regenerateAction() {

--- a/Ollamac/Views/Chats/ChatView.swift
+++ b/Ollamac/Views/Chats/ChatView.swift
@@ -64,6 +64,7 @@ struct ChatView: View {
                         }
                     } trailingAccessory: {
                         CircleButton(systemImage: messageViewModel.loading == .generate ? "stop.fill" : "arrow.up", action: generateAction)
+                            .disabled(prompt.isEmpty)
                     } footer: {
                         if chatViewModel.loading != nil {
                             ProgressView()
@@ -140,7 +141,8 @@ struct ChatView: View {
     
     private func generateAction() {
         guard let activeChat = chatViewModel.activeChat, !activeChat.model.isEmpty, chatViewModel.isHostReachable else { return }
-        
+        guard !prompt.isEmpty else { return }
+
         if messageViewModel.loading == .generate {
             messageViewModel.cancelGeneration()
         } else {


### PR DESCRIPTION
As described in #123, empty prompts are irritating and should not be send to the model.

This change adds check to avoid empty prompts and pre-processes the prompt trimming whitespaces from the string before seeing it to the model.