### PR TITLE
Fixing "stop" button while generation is ongoing

### DIFF
--- a/Ollamac/Views/Chats/ChatView.swift
+++ b/Ollamac/Views/Chats/ChatView.swift
@@ -64,7 +64,7 @@ struct ChatView: View {
                         }
                     } trailingAccessory: {
                         CircleButton(systemImage: messageViewModel.loading == .generate ? "stop.fill" : "arrow.up", action: generateAction)
-                            .disabled(prompt.isEmpty)
+                            .disabled(prompt.isEmpty && messageViewModel.loading != .generate)
                     } footer: {
                         if chatViewModel.loading != nil {
                             ProgressView()
@@ -142,15 +142,15 @@ struct ChatView: View {
     private func generateAction() {
         guard let activeChat = chatViewModel.activeChat, !activeChat.model.isEmpty, chatViewModel.isHostReachable else { return }
 
-        let prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !prompt.isEmpty else {
-            self.prompt = ""
-            return
-        }
-
         if messageViewModel.loading == .generate {
             messageViewModel.cancelGeneration()
         } else {
+            let prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !prompt.isEmpty else {
+                self.prompt = ""
+                return
+            }
+
             guard let activeChat = chatViewModel.activeChat else { return }
             
             messageViewModel.generate(ollamaKit, activeChat: activeChat, prompt: prompt)


### PR DESCRIPTION
By accident in #124 I have introduced a bug which broke the "stop" button while the model is generating output.

This is fixed with the provided patches.