### PR TITLE
Initial version of "export as markdown" functionality

### DIFF
--- a/Ollamac.xcodeproj/project.pbxproj
+++ b/Ollamac.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		0AFC5AA52C6694F400A148A2 /* ExperimentalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFC5AA42C6694F400A148A2 /* ExperimentalView.swift */; };
 		0AFC5AA72C6695CF00A148A2 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFC5AA62C6695CF00A148A2 /* Box.swift */; };
 		0AFC5AA92C66A20C00A148A2 /* CodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFC5AA82C66A20C00A148A2 /* CodeBlockView.swift */; };
+		173D20662D556F350069CD5A /* Chat-Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173D20652D556F2B0069CD5A /* Chat-Export.swift */; };
 		175D318C2C64ADF9009B58E0 /* DefaultFontSizeField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175D318B2C64ADF9009B58E0 /* DefaultFontSizeField.swift */; };
 		4A4A8EBE2D5047590065A5EC /* String+ReplaceAndTrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A8EBD2D5047590065A5EC /* String+ReplaceAndTrim.swift */; };
 /* End PBXBuildFile section */
@@ -98,6 +99,7 @@
 		0AFC5AA42C6694F400A148A2 /* ExperimentalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentalView.swift; sourceTree = "<group>"; };
 		0AFC5AA62C6695CF00A148A2 /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		0AFC5AA82C66A20C00A148A2 /* CodeBlockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeBlockView.swift; sourceTree = "<group>"; };
+		173D20652D556F2B0069CD5A /* Chat-Export.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Chat-Export.swift"; sourceTree = "<group>"; };
 		175D318B2C64ADF9009B58E0 /* DefaultFontSizeField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFontSizeField.swift; sourceTree = "<group>"; };
 		4A4A8EBD2D5047590065A5EC /* String+ReplaceAndTrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ReplaceAndTrim.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -259,6 +261,7 @@
 				0AF5664B2C65A2B400D6E01A /* SectionFooter.swift */,
 				0ADB96122C5D5CC400EB0C60 /* CodeHighlighter.swift */,
 				0AFC5AA82C66A20C00A148A2 /* CodeBlockView.swift */,
+				173D20652D556F2B0069CD5A /* Chat-Export.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -433,6 +436,7 @@
 				0AF5CB622C62B0B600DF8DA8 /* UpdateOllamaHostSheet.swift in Sources */,
 				4A4A8EBE2D5047590065A5EC /* String+ReplaceAndTrim.swift in Sources */,
 				0A6E85102C5E6C670030A4AA /* MessageViewModel.swift in Sources */,
+				173D20662D556F350069CD5A /* Chat-Export.swift in Sources */,
 				0A6E85112C5E6C670030A4AA /* ChatViewModel.swift in Sources */,
 				175D318C2C64ADF9009B58E0 /* DefaultFontSizeField.swift in Sources */,
 				0A6E85342C5F9DA00030A4AA /* ChatFieldFooterView.swift in Sources */,

--- a/Ollamac/Resources/Ollamac.entitlements
+++ b/Ollamac/Resources/Ollamac.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/Ollamac/Utils/Chat-Export.swift
+++ b/Ollamac/Utils/Chat-Export.swift
@@ -1,0 +1,104 @@
+//
+//  Chat-Export.swift
+//  Ollamac
+//
+//  Created by Philipp on 06.02.2025.
+//
+
+import CoreTransferable
+
+extension Chat: Transferable {
+    static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: .plainText) { chat in
+            chat.markdown().data(using: .utf8) ?? Data()
+        }
+    }
+}
+
+extension Chat {
+    var chatName: String {
+        return name.isEmpty ? "New Chat" : name.trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
+    }
+
+    var chatFilename: String {
+        chatName.replacingOccurrences(of: " ", with: "_") + ".md"
+    }
+
+    func markdown() -> String {
+        let sortedMessages = messages.sorted(by: { $0.createdAt < $1.createdAt })
+
+        let name = chatName
+        var markdown = "# \(name)\n\n## Conversation\n\n"
+
+        for message in sortedMessages {
+
+            // User prompt (plain text)
+            let prompt = message.prompt
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: "\n", with: "\n> ")
+                .replacingOccurrences(of: "\n> \n", with: "\n>\n")
+            markdown += "### User\n\n> \(prompt)\n\n"
+
+            // response (markdown)
+            var response = message.response?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+            // process <think> block by indenting its content and escaping HTML tags
+            if let start = response.ranges(of: "<think>").first {
+                if let end = response.ranges(of: /<\/think>\s+/).last {
+                    var thinkBlock = String(response[start.upperBound..<end.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+                    // Escape HTML special characters
+                    thinkBlock = thinkBlock
+                        .replacingOccurrences(of: "&", with: "&amp;")
+                        .replacingOccurrences(of: "<", with: "&lt;")
+                        .replacingOccurrences(of: ">", with: "&gt;")
+
+                    // Indent for blockquote formatting
+                    thinkBlock = "> " + thinkBlock.replacingOccurrences(of: "\n", with: "\n> ")
+                    thinkBlock = thinkBlock.replacingOccurrences(of: "\n> \n", with: "\n>\n")
+
+                    // Replace the <think> block in the response with formatted content
+                    response.replaceSubrange(start.lowerBound..<end.upperBound, with: thinkBlock+"\n\n")
+                }
+            }
+            markdown += "### AI\n\n\(response)\n\n"
+
+            markdown += "---\n\n"
+        }
+
+        markdown += """
+        ## Stats
+        
+        | **Property** | **Value** |
+        |--------------|-----------------------------|
+        | Model        | \(model) |
+        | Created at   | \(createdAt.formatted(date: .numeric, time: .complete)) |
+        | Modified at  | \(modifiedAt.formatted(date: .numeric, time: .complete)) |
+        | Messages     | \(messages.count) |
+
+        """
+
+        if let host = host {
+            markdown += "| Host        | \(host) |\n"
+        }
+
+        if let systemPrompt = systemPrompt {
+            markdown += "| System Prompt | \(systemPrompt.replacingOccurrences(of: "\n", with: " ")) |\n"
+        }
+
+        if let temperature = temperature {
+            markdown += "| Temperature  | \(temperature) |\n"
+        }
+
+        if let topP = topP {
+            markdown += "| Top P       | \(topP) |\n"
+        }
+
+        if let topK = topK {
+            markdown += "| Top K       | \(topK) |\n"
+        }
+
+        return markdown
+    }
+
+}

--- a/Ollamac/Views/Chats/ChatView.swift
+++ b/Ollamac/Views/Chats/ChatView.swift
@@ -24,6 +24,7 @@ struct ChatView: View {
     @State private var prompt: String = ""
     @State private var scrollProxy: ScrollViewProxy? = nil
     @State private var isPreferencesPresented: Bool = false
+    @State private var isExporting: Bool = false
     @FocusState private var isFocused: Bool
 
     init() {
@@ -124,6 +125,20 @@ struct ChatView: View {
         .navigationTitle(chatViewModel.activeChat?.name ?? "Ollamac")
         .navigationSubtitle(chatViewModel.activeChat?.model ?? "")
         .toolbar {
+            ToolbarItem {
+                Button("Share", systemImage: "square.and.arrow.up") {
+                    isExporting = true
+                }
+                .disabled(chatViewModel.activeChat?.messages.count ?? 0 == 0)
+                .fileExporter(isPresented: $isExporting,
+                              item: chatViewModel.activeChat,
+                              contentTypes: [.plainText],
+                              defaultFilename: chatViewModel.activeChat?.chatFilename ?? "Ollamac_Chat.txt"
+                ) { result in
+                    // handle error?
+                    print(result)
+                }
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button("Show Preferences", systemImage: "sidebar.trailing") {
                     isPreferencesPresented.toggle()


### PR DESCRIPTION
This is a preview of a possible "export" functionality.

- a "share button" in the chat's toolbar triggers the save dialog (using `fileExporter`)
- the chat with its messages and some statistics is "rendered manually" into a markdown string
- the string  is saved using the `Transferable` protocol

Happy to receive feedback...

For each message:
- the prompt is rendered into a markdown "quote block", so indenting the users input.
- the response is checked for a &lt;think&gt; block. If found, this part is put into a quote block as the users input.
- the rest of the response is added "as is" (as we expect it to be proper markdown)

There are known issues:
- if the prompt contains markdown formatting, this might look ugly/break
- HTML entities are only escaped in the &lt;think&gt; block. But if the &lt; &amp; or &gt; are already escaped in markdown (using backticks ` or ```) this is incorrect.