### PR TITLE
Handle incomplete response

### DIFF
--- a/Ollamac/ViewModels/MessageViewModel.swift
+++ b/Ollamac/ViewModels/MessageViewModel.swift
@@ -72,6 +72,29 @@ final class MessageViewModel {
                         }
                     }
                 }
+
+                // If chunk was not done: handle temporary response
+                if !tempResponse.isEmpty {
+                    // properly close <think> block
+                    if tempResponse.matches(of: /<\/?think>/).count == 1 {
+                        tempResponse += "\n</think>\n"
+                    }
+
+                    // properly close any code blocks
+                    if tempResponse.matches(of: /```/).count % 2 == 1 {
+                        tempResponse += "\n```\n"
+                    } else {
+                        // ... or add a visual separator
+                        tempResponse += "\n\n---\n"
+                    }
+
+                    // mark response as cancelled
+                    tempResponse += "\n_CANCELLED_"
+
+                    message.response = tempResponse
+                    activeChat.modifiedAt = .now
+                    tempResponse = ""
+                }
             } catch {
                 self.error = .generate(error.localizedDescription)
             }
@@ -101,6 +124,29 @@ final class MessageViewModel {
                         activeChat.modifiedAt = .now
                         tempResponse = ""
                     }
+                }
+
+                // If chunk was not done: handle temporary response
+                if !tempResponse.isEmpty {
+                    // properly close <think> block
+                    if tempResponse.matches(of: /<\/?think>/).count == 1 {
+                        tempResponse += "\n</think>\n"
+                    }
+
+                    // properly close any code blocks
+                    if tempResponse.matches(of: /```/).count % 2 == 1 {
+                        tempResponse += "\n```\n"
+                    } else {
+                        // ... or add a visual separator
+                        tempResponse += "\n\n---\n"
+                    }
+
+                    // mark response as cancelled
+                    tempResponse += "\n_CANCELLED_"
+
+                    lastMessage.response = tempResponse
+                    activeChat.modifiedAt = .now
+                    tempResponse = ""
                 }
             } catch {
                 self.error = .generate(error.localizedDescription)


### PR DESCRIPTION
Due to a task cancellation, the response can be incomplete.
- `tempResponse` must be cleared, otherwise regeneration will append its response to the same message.
- response should highlighted as incomplete/cancelled/aborted

This PR is most useful with https://github.com/kevinhermawan/OllamaKit/pull/44 as it implements cancellation of the network request.

Two screenshots below: cancellation while code and while text was generated. It's clearly marked as cancelled.

<img width="187" alt="Cancelled Code block" src="https://github.com/user-attachments/assets/963704a9-6944-4cd3-b210-8878b21fa13a" />

<img width="301" alt="Cancelled text response" src="https://github.com/user-attachments/assets/3fb9b182-4411-4e69-beb7-c79037312cf2" />

