### PR TITLE
Fix: no new chat - if it there is already one

### DIFF
--- a/Ollamac/App/OllamacApp.swift
+++ b/Ollamac/App/OllamacApp.swift
@@ -48,13 +48,6 @@ struct OllamacApp: App {
 
         let codeHighlighter =  CodeHighlighter(colorScheme: .light, fontSize: Defaults[.fontSize], enabled: Defaults[.experimentalCodeHighlighting])
         _codeHighlighter = State(initialValue: codeHighlighter)
-
-        chatViewModel.create(model: Defaults[.defaultModel])
-        guard let activeChat = chatViewModel.selectedChats
-            .first else { return }
-        
-        chatViewModel.activeChat = activeChat
-        messageViewModel.load(of: activeChat)
     }
     
     var body: some Scene {

--- a/Ollamac/Models/Chat.swift
+++ b/Ollamac/Models/Chat.swift
@@ -40,4 +40,8 @@ final class Chat: Identifiable {
     @Transient var firstMessage: Message? {
         return messages.sorted { $0.createdAt < $1.createdAt }.first
     }
+
+    var isNew: Bool {
+        name == Defaults[.defaultChatName] && messages.isEmpty
+    }
 }

--- a/Ollamac/ViewModels/ChatViewModel.swift
+++ b/Ollamac/ViewModels/ChatViewModel.swift
@@ -118,10 +118,9 @@ final class ChatViewModel {
     }
     
     func removeTemporaryChat(chatToRemove: Chat) {
-        if (chatToRemove.name == Defaults[.defaultChatName] && chatToRemove.messages.isEmpty) {
-            self.modelContext.delete(chatToRemove)
-            self.chats.removeAll(where: { $0.id == chatToRemove.id })
-        }
+        guard chatToRemove.isNew else { return }
+        self.modelContext.delete(chatToRemove)
+        self.chats.removeAll(where: { $0.id == chatToRemove.id })
     }
 }
 

--- a/Ollamac/ViewModels/ChatViewModel.swift
+++ b/Ollamac/ViewModels/ChatViewModel.swift
@@ -94,11 +94,11 @@ final class ChatViewModel {
     }
     
     func create(model: String) {
-        // There is already a "new" unused chat
-        if let newChat = chats.first(where: { $0.isNew }) {
-            newChat.createdAt = .now
-            newChat.model = model
-            self.selectedChats = [newChat]
+        // There is already a "New Chat" unused chat
+        if let existingChat = chats.first(where: { $0.isNew }) {
+            existingChat.createdAt = .now
+            existingChat.model = model
+            self.selectedChats = [existingChat]
         } else {
             let chat = Chat(model: model)
             self.modelContext.insert(chat)

--- a/Ollamac/ViewModels/ChatViewModel.swift
+++ b/Ollamac/ViewModels/ChatViewModel.swift
@@ -87,17 +87,25 @@ final class ChatViewModel {
             let fetchDescriptor = FetchDescriptor<Chat>(sortBy: [sortDescriptor])
             
             self.chats = try self.modelContext.fetch(fetchDescriptor)
+            self.create(model: Defaults[.defaultModel])
         } catch {
             self.error = .load(error.localizedDescription)
         }
     }
     
     func create(model: String) {
-        let chat = Chat(model: model)
-        self.modelContext.insert(chat)
-        
-        self.chats.insert(chat, at: 0)
-        self.selectedChats = [chat]
+        // There is already a "new" unused chat
+        if let newChat = chats.first(where: { $0.isNew }) {
+            newChat.createdAt = .now
+            newChat.model = model
+            self.selectedChats = [newChat]
+        } else {
+            let chat = Chat(model: model)
+            self.modelContext.insert(chat)
+
+            self.chats.insert(chat, at: 0)
+            self.selectedChats = [chat]
+        }
         self.shouldFocusPrompt = true
     }
     

--- a/Ollamac/Views/Sidebar/SidebarView.swift
+++ b/Ollamac/Views/Sidebar/SidebarView.swift
@@ -104,7 +104,7 @@ struct SidebarView: View {
             if selectedChats.count > 1 {
                 chatViewModel.activeChat = nil
                 messageViewModel.messages = []
-            } else if let activeChat = selectedChats.first {
+            } else if let activeChat = selectedChats.first, chatViewModel.activeChat != activeChat {
                 chatViewModel.activeChat = activeChat
                 messageViewModel.load(of: activeChat)
                 if let oldActiveChat = oldSelectedChats.first {

--- a/Ollamac/Views/Sidebar/SidebarView.swift
+++ b/Ollamac/Views/Sidebar/SidebarView.swift
@@ -104,15 +104,12 @@ struct SidebarView: View {
             if selectedChats.count > 1 {
                 chatViewModel.activeChat = nil
                 messageViewModel.messages = []
-            } else {
-                guard let oldActiveChat = oldSelectedChats.first else { return }
-                chatViewModel.removeTemporaryChat(chatToRemove: oldActiveChat)
-                
-                let selectedChatsArray = Array(selectedChats)
-                guard let activeChat = selectedChatsArray.first else { return }
-                
+            } else if let activeChat = selectedChats.first {
                 chatViewModel.activeChat = activeChat
                 messageViewModel.load(of: activeChat)
+                if let oldActiveChat = oldSelectedChats.first {
+                    chatViewModel.removeTemporaryChat(chatToRemove: oldActiveChat)
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds improvements when creating the initial "New Chat" chat whenever the app starts up.
- The chat is only created after the list of chats has been load
- The new chat is only created if there has not been one found in the current list of chats.
- Not only the name of the chant ("New Chat") is relevant, but also that it does not contain any messages.
- When "New Chat" is called (CMD+N) multiple times, the same chat is reused if it does not contain any messages.