### PR TITLE
Improve rendering speed

### DIFF
--- a/Ollamac/Views/AppView.swift
+++ b/Ollamac/Views/AppView.swift
@@ -5,15 +5,41 @@
 //  Created by Kevin Hermawan on 03/11/23.
 //
 
+import Defaults
+import MarkdownUI
 import SwiftUI
 
 struct AppView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(CodeHighlighter.self) private var codeHighlighter
+
+    @AppStorage("experimentalCodeHighlighting") private var experimentalCodeHighlighting = false
+    @Default(.fontSize) private var fontSize
+
     var body: some View {
         NavigationSplitView {
             SidebarView()
                 .navigationSplitViewColumnWidth(min: 256, ideal: 256)
         } detail: {
             ChatView()
+        }
+        .markdownTextStyle(\.text) {
+            FontSize(CGFloat(fontSize))
+        }
+        .markdownTextStyle(\.code) {
+            FontSize(CGFloat(fontSize))
+            FontFamily(.system(.monospaced))
+        }
+        .markdownTheme(.ollamac)
+        .markdownCodeSyntaxHighlighter(experimentalCodeHighlighting ? codeHighlighter : .plainText)
+        .onChange(of: colorScheme, initial: true) {
+            codeHighlighter.colorScheme = colorScheme
+        }
+        .onChange(of: fontSize, initial: true) {
+            codeHighlighter.fontSize = fontSize
+        }
+        .onChange(of: experimentalCodeHighlighting) {
+            codeHighlighter.enabled = experimentalCodeHighlighting
         }
     }
 }

--- a/Ollamac/Views/Chats/ChatView.swift
+++ b/Ollamac/Views/Chats/ChatView.swift
@@ -5,8 +5,8 @@
 //  Created by Kevin Hermawan on 8/2/24.
 //
 
-import Defaults
 import ChatField
+import Defaults
 import OllamaKit
 import SwiftUI
 import ViewCondition
@@ -14,10 +14,7 @@ import ViewCondition
 struct ChatView: View {
     @Environment(ChatViewModel.self) private var chatViewModel
     @Environment(MessageViewModel.self) private var messageViewModel
-    @Environment(\.colorScheme) private var colorScheme
-    @Environment(CodeHighlighter.self) private var codeHighlighter
 
-    @AppStorage("experimentalCodeHighlighting") private var experimentalCodeHighlighting = false
     @Default(.fontSize) private var fontSize
 
     @State private var ollamaKit: OllamaKit
@@ -110,15 +107,6 @@ struct ChatView: View {
                 if let proxy = scrollProxy {
                     scrollToBottom(proxy: proxy)
                 }
-            }
-            .onChange(of: colorScheme, initial: true) {
-                codeHighlighter.colorScheme = colorScheme
-            }
-            .onChange(of: fontSize, initial: true) {
-                codeHighlighter.fontSize = fontSize
-            }
-            .onChange(of: experimentalCodeHighlighting) {
-                codeHighlighter.enabled = experimentalCodeHighlighting
             }
         }
         .navigationTitle(chatViewModel.activeChat?.name ?? "Ollamac")

--- a/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
+++ b/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
@@ -43,7 +43,7 @@ struct AssistantMessageView: View {
             } else {
 				Markdown(convertThinkTagsToMarkdownQuote(in: content))
                     .textSelection(.enabled)
-                    .if(isGenerating) {
+                    .if(isGenerating && isLastMessage) {
                         $0.markdownCodeSyntaxHighlighter(.plainText)
                     }
                     .id(codeHighlighter.stateHashValue)

--- a/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
+++ b/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
@@ -7,9 +7,9 @@
 
 import Defaults
 import MarkdownUI
+import RegexBuilder
 import SwiftUI
 import ViewCondition
-import RegexBuilder
 
 struct AssistantMessageView: View {
     @Default(.fontSize) private var fontSize
@@ -43,15 +43,6 @@ struct AssistantMessageView: View {
             } else {
 				Markdown(convertThinkTagsToMarkdownQuote(in: content))
                     .textSelection(.enabled)
-                    .markdownTextStyle(\.text) {
-                        FontSize(CGFloat(fontSize))
-                    }
-                    .markdownTextStyle(\.code) {
-                        FontSize(CGFloat(fontSize))
-                        FontFamily(.system(.monospaced))
-                    }
-                    .markdownTheme(.ollamac)
-                    .markdownCodeSyntaxHighlighter(experimentalCodeHighlighting ? codeHighlighter : .plainText)
                     .id(codeHighlighter.stateHashValue)
 
                 HStack(spacing: 16) {

--- a/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
+++ b/Ollamac/Views/Chats/Subviews/AssistantMessageView.swift
@@ -43,6 +43,9 @@ struct AssistantMessageView: View {
             } else {
 				Markdown(convertThinkTagsToMarkdownQuote(in: content))
                     .textSelection(.enabled)
+                    .if(isGenerating) {
+                        $0.markdownCodeSyntaxHighlighter(.plainText)
+                    }
                     .id(codeHighlighter.stateHashValue)
 
                 HStack(spacing: 16) {


### PR DESCRIPTION
- By moving the MarkdownUI initialization code to the `AppView` top view calls to those initialization functions could be reduced a lot for longer chats.
- By disabling syntax highlighting while chat generation/regeneration is going on, the rendering speed could be improved a lot. Especially for long responses with a lot of code. It is now safe to keep syntax highlighting on by default 😃